### PR TITLE
chore: sync Dependabot config from trend-radar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
     schedule:
       interval: weekly
     cooldown:
+      default-days: 7
       semver-major-days: 14
       semver-minor-days: 3
       semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 10
     groups:
-      actions-minor:
+      actions-all:
         update-types:
+          - major
           - minor
           - patch
 
@@ -18,18 +18,18 @@ updates:
     schedule:
       interval: weekly
     cooldown:
-      default-days: 7
-      semver-major-days: 7
+      semver-major-days: 14
       semver-minor-days: 3
-      semver-patch-days: 2
-    open-pull-requests-limit: 10
+      semver-patch-days: 3
     groups:
       npm-development:
         dependency-type: development
         update-types:
+          - major
           - minor
           - patch
       npm-production:
         dependency-type: production
         update-types:
+          - minor
           - patch


### PR DESCRIPTION
Ports the Dependabot improvements made in `chrisreddington/trend-radar` to this repo.

## Changes

**`.github/dependabot.yml`**
- **GitHub Actions**: Renamed group to `actions-all` and added `major` updates so all Action bumps are batched into a single grouped PR
- **GitHub Actions**: Removed `open-pull-requests-limit` — grouping makes it redundant
- **npm cooldown**: Switched from a generic `default-days` to per-semver granularity (`semver-major-days: 14`, `minor: 3`, `patch: 3`) for finer control
- **npm-development**: Added `major` to the group so dev dependency majors are also batched
- **npm-production**: Added `minor` updates so minor production bumps are batched and eligible for auto-merge
- **npm**: Removed `open-pull-requests-limit`

The `dependabot-automerge.yml` workflow is already in sync with trend-radar (auto-approves and squash-merges patch + minor updates).